### PR TITLE
Do not treat missing ancestor as input mismatch

### DIFF
--- a/src/cyclebane/graph.py
+++ b/src/cyclebane/graph.py
@@ -430,7 +430,10 @@ class Graph:
         intersection_nodes = set(graph.nodes) & set(new_branch.nodes) - {branch}
 
         for node in intersection_nodes:
-            if graph.pred[node] != new_branch.pred[node]:
+            # Missing ancestors in `new_branch` will be filled in from `graph`.
+            new_pred = new_branch.pred[node]
+            old_pred = {k: v for k, v in graph.pred[node].items() if k in new_pred}
+            if old_pred != new_pred:
                 raise ValueError(
                     f"Node inputs differ for node '{node}':\n"
                     f"  {graph.pred[node]}\n"

--- a/src/cyclebane/graph.py
+++ b/src/cyclebane/graph.py
@@ -430,10 +430,8 @@ class Graph:
         intersection_nodes = set(graph.nodes) & set(new_branch.nodes) - {branch}
 
         for node in intersection_nodes:
-            # Missing ancestors in `new_branch` will be filled in from `graph`.
             new_pred = new_branch.pred[node]
-            old_pred = {k: v for k, v in graph.pred[node].items() if k in new_pred}
-            if old_pred != new_pred:
+            if new_pred and graph.pred[node] != new_pred:
                 raise ValueError(
                     f"Node inputs differ for node '{node}':\n"
                     f"  {graph.pred[node]}\n"

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -653,22 +653,6 @@ def test_setitem_inserts_graph_with_missing_parent() -> None:
     nx.utils.graphs_equal(graph.to_networkx(), expected)
 
 
-def test_setitem_inserts_graph_with_missing_and_matching_parent() -> None:
-    g1 = nx.DiGraph()
-    g1.add_edge('a', 'b')
-    g1.add_edge('e', 'b')
-    g1.add_edge('n', 'c')
-    g2 = nx.DiGraph()
-    g2.add_edge('b', 'n')
-    g2.add_edge('e', 'b')
-
-    graph = cb.Graph(g1)
-    graph['n'] = cb.Graph(g2)
-    expected = g1.copy()
-    expected.add_edge('b', 'n')
-    nx.utils.graphs_equal(graph.to_networkx(), expected)
-
-
 def test_setitem_fails_with_partial_parent_mismatch() -> None:
     g1 = nx.DiGraph()
     g1.add_edge('a', 'b')  # only in g1
@@ -682,6 +666,20 @@ def test_setitem_fails_with_partial_parent_mismatch() -> None:
     graph = cb.Graph(g1)
     with pytest.raises(ValueError, match="Node inputs differ for node 'b'"):
         graph['n'] = cb.Graph(g2)
+
+
+def test_setitem_fails_when_grandparents_change() -> None:
+    g1 = nx.DiGraph()
+    g1.add_edge('a1', 'b')
+    g1.add_edge('a2', 'b')
+    g1.add_edge('b', 'c')
+    g2 = nx.DiGraph()  # no a2 -> b edge
+    g2.add_edge('a1', 'b')
+    g2.add_edge('b', 'c')
+
+    graph = cb.Graph(g1)
+    with pytest.raises(ValueError, match="Node inputs differ for node 'b'"):
+        graph['c'] = cb.Graph(g2)
 
 
 def test_getitem_returns_graph_containing_only_key_and_ancestors() -> None:

--- a/tests/graph_test.py
+++ b/tests/graph_test.py
@@ -639,6 +639,51 @@ def test_setitem_preserves_nodes_that_are_ancestors_of_unrelated_node() -> None:
     nx.utils.graphs_equal(graph.to_networkx(), g)
 
 
+def test_setitem_inserts_graph_with_missing_parent() -> None:
+    g1 = nx.DiGraph()
+    g1.add_edge('a', 'b')
+    g1.add_edge('n', 'c')
+    g2 = nx.DiGraph()
+    g2.add_edge('b', 'n')
+
+    graph = cb.Graph(g1)
+    graph['n'] = cb.Graph(g2)
+    expected = g1.copy()
+    expected.add_edge('b', 'n')
+    nx.utils.graphs_equal(graph.to_networkx(), expected)
+
+
+def test_setitem_inserts_graph_with_missing_and_matching_parent() -> None:
+    g1 = nx.DiGraph()
+    g1.add_edge('a', 'b')
+    g1.add_edge('e', 'b')
+    g1.add_edge('n', 'c')
+    g2 = nx.DiGraph()
+    g2.add_edge('b', 'n')
+    g2.add_edge('e', 'b')
+
+    graph = cb.Graph(g1)
+    graph['n'] = cb.Graph(g2)
+    expected = g1.copy()
+    expected.add_edge('b', 'n')
+    nx.utils.graphs_equal(graph.to_networkx(), expected)
+
+
+def test_setitem_fails_with_partial_parent_mismatch() -> None:
+    g1 = nx.DiGraph()
+    g1.add_edge('a', 'b')  # only in g1
+    g1.add_edge('e', 'b')  # in both graphs
+    g1.add_edge('n', 'c')
+    g2 = nx.DiGraph()
+    g2.add_edge('b', 'n')
+    g2.add_edge('e', 'b')  # in both graphs
+    g2.add_edge('x', 'b')  # only in g2
+
+    graph = cb.Graph(g1)
+    with pytest.raises(ValueError, match="Node inputs differ for node 'b'"):
+        graph['n'] = cb.Graph(g2)
+
+
 def test_getitem_returns_graph_containing_only_key_and_ancestors() -> None:
     g = nx.DiGraph()
     g.add_edge('a', 'b')


### PR DESCRIPTION
This should fix https://github.com/scipp/sciline/issues/180.

If `new_branch` has no ancestors, it should be safe to insert it and use the ancestors of `self`.

@SimonHeybrock `test_setitem_fails_when_grandparents_change` is failing. I think this test should pass. But in `__setitem__`, we get `intersection_nodes = set()` because 
```python
        if branch in self.graph:
            graph = _remove_ancestors(self.graph, branch)
            graph.nodes[branch].clear()
```
removes all ancestors but `'c'` such that
```python
intersection_nodes = set(graph.nodes) & set(new_branch.nodes) - {branch}
# equals
intersection_nodes = {'c'} & {'a1', 'b', 'c'} - {'c'}
```
Is this how it should behave? Or is there currently a bug?